### PR TITLE
SDES-1707: BulkDownload API Changing from Public to Private

### DIFF
--- a/app/uk/gov/hmrc/sdes/bulkdownload/config/AppStartup.scala
+++ b/app/uk/gov/hmrc/sdes/bulkdownload/config/AppStartup.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/sdes/bulkdownload/config/SdesModule.scala
+++ b/app/uk/gov/hmrc/sdes/bulkdownload/config/SdesModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/sdes/bulkdownload/config/SdesServicesConfig.scala
+++ b/app/uk/gov/hmrc/sdes/bulkdownload/config/SdesServicesConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,4 +25,7 @@ import uk.gov.hmrc.play.config.ServicesConfig
 class SdesServicesConfig @Inject()(override val runModeConfiguration: Configuration,
                                    environment: Environment) extends ServicesConfig {
   override protected def mode: Mode = environment.mode
+
+  val apiAccessWhitelistedApplicationIds: Seq[String] =
+    runModeConfiguration.getStringSeq("api.access.white-list.applicationIds").getOrElse(Nil)
 }

--- a/app/uk/gov/hmrc/sdes/bulkdownload/connectors/SdesListFilesConnector.scala
+++ b/app/uk/gov/hmrc/sdes/bulkdownload/connectors/SdesListFilesConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/sdes/bulkdownload/connectors/ServiceLocatorConnector.scala
+++ b/app/uk/gov/hmrc/sdes/bulkdownload/connectors/ServiceLocatorConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/sdes/bulkdownload/controllers/ApiDocumentationController.scala
+++ b/app/uk/gov/hmrc/sdes/bulkdownload/controllers/ApiDocumentationController.scala
@@ -14,10 +14,20 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.sdes.bulkdownload.utils
+package uk.gov.hmrc.sdes.bulkdownload.controllers
 
-object TestUtils {
-  val host = "localhost"
-  val port: Int = scala.util.Properties.envOrElse("MOCK_SERVER_PORT", "1234").toInt
-  val url = s"http://$host:$port"
+import javax.inject.{Inject, Singleton}
+import play.api.http.ContentTypes
+import play.api.mvc.{Action, AnyContent}
+import uk.gov.hmrc.play.bootstrap.controller.BaseController
+import uk.gov.hmrc.sdes.bulkdownload.config.SdesServicesConfig
+import uk.gov.hmrc.sdes.bulkdownload.views
+
+@Singleton
+class ApiDocumentationController @Inject()(servicesConfig: SdesServicesConfig) extends BaseController {
+
+  def definition(): Action[AnyContent] = Action {
+    Ok(views.txt.definition(servicesConfig.apiAccessWhitelistedApplicationIds)).as(ContentTypes.JSON)
+  }
+
 }

--- a/app/uk/gov/hmrc/sdes/bulkdownload/controllers/BulkDownloadController.scala
+++ b/app/uk/gov/hmrc/sdes/bulkdownload/controllers/BulkDownloadController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/sdes/bulkdownload/model/FileItem.scala
+++ b/app/uk/gov/hmrc/sdes/bulkdownload/model/FileItem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/sdes/bulkdownload/views/definition.scala.txt
+++ b/app/uk/gov/hmrc/sdes/bulkdownload/views/definition.scala.txt
@@ -1,3 +1,4 @@
+@(whitelistedApplicationIds: Seq[String])
 {
   "scopes": [
     {
@@ -15,7 +16,8 @@
         "version": "1.0",
         "status": "BETA",
         "access": {
-          "type": "PUBLIC"
+          "type": "PRIVATE",
+          "whitelistedApplicationIds": @{play.api.libs.json.Json.toJson(whitelistedApplicationIds)}
         },
         "endpointsEnabled": true
       }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -4,6 +4,6 @@ GET        /list/:fileType             uk.gov.hmrc.sdes.bulkdownload.controllers
 
 POST       /list/:fileType             uk.gov.hmrc.sdes.bulkdownload.controllers.BulkDownloadController.methodNotAllowed(fileType)
 
-GET        /api/definition             @controllers.Assets.at(path="/public/api", file="definition.json")
+GET        /api/definition             @uk.gov.hmrc.sdes.bulkdownload.controllers.ApiDocumentationController.definition()
 
 GET        /api/conf/*file             @controllers.Assets.at(path="/public/api/conf", file)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2018 HM Revenue & Customs
+# Copyright 2019 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/sdes/bulkdownload/acceptance/BulkDownloadListSpec.scala
+++ b/test/uk/gov/hmrc/sdes/bulkdownload/acceptance/BulkDownloadListSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/sdes/bulkdownload/acceptance/MDTPEndpointsSpec.scala
+++ b/test/uk/gov/hmrc/sdes/bulkdownload/acceptance/MDTPEndpointsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,12 +22,15 @@ import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Helpers}
+import uk.gov.hmrc.sdes.bulkdownload.utils.TestData
+import uk.gov.hmrc.sdes.bulkdownload.utils.TestData.applicationIds
 
 import scala.io.Source
 
 class MDTPEndpointsSpec extends PlaySpec with GuiceOneAppPerSuite {
 
   override implicit lazy val app: Application = GuiceApplicationBuilder()
+    .configure(applicationIds.zipWithIndex.map { case (id, i) => s"api.access.white-list.applicationIds.$i" -> id }: _*)
     .configure("microservice.services.service-locator.enabled" -> false,
       "auditing.enabled" -> false)
     .build()
@@ -41,7 +44,7 @@ class MDTPEndpointsSpec extends PlaySpec with GuiceOneAppPerSuite {
       val Some(result) = route(app, req)
 
       status(result) mustBe OK
-      contentAsString(result) mustBe readResourceFile("/public/api/definition.json")
+      contentAsJson(result) mustBe TestData.expectedDefinitionJson(applicationIds)
     }
   }
 

--- a/test/uk/gov/hmrc/sdes/bulkdownload/config/AppStartupSpec.scala
+++ b/test/uk/gov/hmrc/sdes/bulkdownload/config/AppStartupSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/sdes/bulkdownload/config/SdesServicesConfigSpec.scala
+++ b/test/uk/gov/hmrc/sdes/bulkdownload/config/SdesServicesConfigSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.sdes.bulkdownload.config
+
+import java.io.File
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.mockito.MockitoSugar
+import play.api.{Configuration, Environment, Mode}
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.sdes.bulkdownload.utils.TestData._
+
+class SdesServicesConfigSpec extends UnitSpec with MockitoSugar {
+
+  trait Setup {
+    def configFileContent: String
+
+    val runMode = Mode.Test
+
+    lazy val servicesConfig = {
+      val config = Configuration(ConfigFactory.parseString(configFileContent))
+      val env = Environment(mock[File], mock[ClassLoader], runMode)
+
+      new SdesServicesConfig(config, env)
+    }
+  }
+
+  "SdesServicesConfigSpec" should {
+    "read whitelisted application ids from config" in new Setup {
+      override val configFileContent =
+        s"""
+           |api.access.white-list.applicationIds.0 = $id1
+           |api.access.white-list.applicationIds.1 = $id2
+           |api.access.white-list.applicationIds.2 = $id3
+        """.stripMargin
+
+      servicesConfig.apiAccessWhitelistedApplicationIds shouldBe applicationIds
+    }
+
+    "give empty list if whitelisted application ids not configured" in new Setup {
+      override val configFileContent = ""
+      servicesConfig.apiAccessWhitelistedApplicationIds shouldBe Nil
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/sdes/bulkdownload/connectors/ServiceLocatorConnectorSpec.scala
+++ b/test/uk/gov/hmrc/sdes/bulkdownload/connectors/ServiceLocatorConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/sdes/bulkdownload/controllers/ApiDocumentationControllerSpec.scala
+++ b/test/uk/gov/hmrc/sdes/bulkdownload/controllers/ApiDocumentationControllerSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.sdes.bulkdownload.controllers
+
+import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+import play.api.http.ContentTypes
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.sdes.bulkdownload.config.SdesServicesConfig
+import uk.gov.hmrc.sdes.bulkdownload.utils.TestData._
+
+class ApiDocumentationControllerSpec extends UnitSpec with MockitoSugar {
+
+  "ApiDocumentationController" should {
+    "render definition.json with whitelisted application ids" in {
+      val mockConfig = mock[SdesServicesConfig]
+      val controller = new ApiDocumentationController(mockConfig)
+
+      when(mockConfig.apiAccessWhitelistedApplicationIds).thenReturn(applicationIds)
+
+      val result = controller.definition()(FakeRequest())
+
+      status(result) shouldBe OK
+      contentType(result) shouldBe Some(ContentTypes.JSON)
+      contentAsJson(result) shouldBe expectedDefinitionJson(applicationIds)
+
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/sdes/bulkdownload/controllers/BulkDownloadControllerSpec.scala
+++ b/test/uk/gov/hmrc/sdes/bulkdownload/controllers/BulkDownloadControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/sdes/bulkdownload/controllers/RoutesSpec.scala
+++ b/test/uk/gov/hmrc/sdes/bulkdownload/controllers/RoutesSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.sdes.bulkdownload.controllers
+
+import org.mockito.Mockito
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc.Controller
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.sdes.bulkdownload.config.SdesModule
+
+class RoutesSpec extends UnitSpec with BeforeAndAfterEach with GuiceOneAppPerSuite with MockitoSugar {
+
+  val allControllers@(
+    mockApiDocumentationController,
+    mockBulkDownloadController) = (
+    mock[ApiDocumentationController],
+    mock[BulkDownloadController]
+  )
+
+  private def forEachController(f: Controller => Unit): Unit =
+    allControllers.productIterator.foreach { case c: Controller => f(c) }
+
+  override protected def beforeEach(): Unit = {
+    forEachController(Mockito.reset(_))
+  }
+
+  override def fakeApplication(): Application = new GuiceApplicationBuilder()
+    .overrides(bind[ApiDocumentationController] toInstance mockApiDocumentationController)
+    .overrides(bind[BulkDownloadController] toInstance mockBulkDownloadController)
+    .configure("microservice.services.service-locator.enabled" -> false)
+    .configure("auditing.enabled" -> false)
+    .disable(classOf[SdesModule])
+    .build()
+
+  private val fileType = "FILETYPE"
+
+  val routes = Seq(
+    (GET, "/api/definition", () => verify(mockApiDocumentationController).definition()),
+    (GET, s"/list/$fileType", () => verify(mockBulkDownloadController).list(fileType))
+  )
+
+  "routes" should {
+    routes.foreach { case (method, url, verification) =>
+      s"properly route $method $url" in {
+        route(app, FakeRequest(method, url))
+        verification.apply()
+      }
+    }
+
+    "not route unknown urls" in {
+      Seq(GET, POST) foreach { method =>
+        route(app, FakeRequest(method, "/rubbish"))
+        forEachController(verifyZeroInteractions(_))
+      }
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/sdes/bulkdownload/utils/TestData.scala
+++ b/test/uk/gov/hmrc/sdes/bulkdownload/utils/TestData.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.sdes.bulkdownload.utils
+
+import play.api.libs.json.{JsValue, Json}
+
+object TestData {
+
+  val applicationIds @ Seq(id1, id2, id3) = Seq("id1", "id2", "id3")
+
+  def expectedDefinitionJson(whitelistedApplicationIds: Seq[String] = applicationIds): JsValue = Json.parse(
+    s"""
+       |{
+       |  "scopes": [
+       |    {
+       |      "key": "read:bulk-data-download-list",
+       |      "name": "List Available Files",
+       |      "description": "List files available for download from SDES"
+       |    }
+       |  ],
+       |  "api": {
+       |    "name": "Bulk Data File List",
+       |    "description": "An API informing about files available for download from Secure Data Exchange Services.",
+       |    "context": "bulk-data-download",
+       |    "versions": [
+       |      {
+       |        "version": "1.0",
+       |        "status": "BETA",
+       |        "access": {
+       |          "type": "PRIVATE",
+       |          "whitelistedApplicationIds":[ ${whitelistedApplicationIds.map(Json.toJson(_)).mkString(",")} ]
+       |        },
+       |        "endpointsEnabled": true
+       |      }
+       |    ]
+       |  }
+       |}
+         """.stripMargin
+  )
+
+}

--- a/test/uk/gov/hmrc/sdes/bulkdownload/utils/wiremock/MockSdesProxyListFilesEndpoint.scala
+++ b/test/uk/gov/hmrc/sdes/bulkdownload/utils/wiremock/MockSdesProxyListFilesEndpoint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/sdes/bulkdownload/utils/wiremock/WireMockRunner.scala
+++ b/test/uk/gov/hmrc/sdes/bulkdownload/utils/wiremock/WireMockRunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- dynamic `definition.scala.txt` view rather than a static file `definition.json`
- configuring whitelisted application ids with the key `api.access.white-list.applicationIds`
- automagically updated the current year in License header of the source files